### PR TITLE
feat: allow floating menu tooltip to be triggered onhover

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -539,6 +539,16 @@
       "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -4054,8 +4064,8 @@
       "integrity": "sha512-jaAP61py+ISMF3/n3yIiIuY5h6mJlucOqawu5mLB1HaQADLvg/y5UB3pT7HSucZJan34lp7+7ylQPfbKEGmxrA==",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.2",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.5",
         "meow": "4.0.0",
         "split2": "2.2.0",
@@ -7438,14 +7448,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -7454,6 +7456,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -10287,16 +10297,6 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -17300,15 +17300,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -17373,6 +17364,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {

--- a/src/components/Select/_select.scss
+++ b/src/components/Select/_select.scss
@@ -34,6 +34,11 @@
       outline: none;
       @include mi-underline-focus;
     }
+
+    &:-moz-focusring {
+      color: transparent;
+      text-shadow: 0 0 0 $text-01;
+    }
   }
 
   .#{$prefix}--select__arrow {

--- a/src/components/Select/_select.scss
+++ b/src/components/Select/_select.scss
@@ -34,6 +34,10 @@
       outline: none;
       @include mi-underline-focus;
     }
+    &:-moz-focusring {
+      color: transparent;
+      text-shadow: 0 0 0 $text-01;
+    }
   }
 
   .#{$prefix}--select__arrow {

--- a/src/components/Select/_select.scss
+++ b/src/components/Select/_select.scss
@@ -58,6 +58,10 @@
     }
   }
 
+  .#{$prefix}--select-option {
+    padding: 0.25rem;
+  }
+
   // Override some Firefox user-agent styles
   @-moz-document url-prefix() {
     .#{$prefix}--select-option {

--- a/src/components/Select/_select.scss
+++ b/src/components/Select/_select.scss
@@ -34,10 +34,6 @@
       outline: none;
       @include mi-underline-focus;
     }
-    &:-moz-focusring {
-      color: transparent;
-      text-shadow: 0 0 0 $text-01;
-    }
   }
 
   .#{$prefix}--select__arrow {

--- a/src/components/Tooltip/Tooltip-story.js
+++ b/src/components/Tooltip/Tooltip-story.js
@@ -28,4 +28,22 @@ storiesOf('Components|Tooltip', module)
         </Tooltip>
       </div>
     )),
+  )
+  .add(
+    'Complex tooltip on hover',
+    withInfo('This example shows a floating tooltip that appears on hover.')(() => (
+      <div style={{ marginTop: '2rem' }}>
+        <Tooltip openOnHover triggerText="Tooltip label">
+          <p className="bx--tooltip__label">Tooltip subtitle</p>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+            dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            Excepteur sint occaeca cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
+          </p>
+        </Tooltip>
+      </div>
+    )),
   );

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -15,6 +15,7 @@ export default class Tooltip extends Component {
     showIcon: PropTypes.bool,
     iconName: PropTypes.string,
     iconDescription: PropTypes.string,
+    openOnHover: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -25,10 +26,11 @@ export default class Tooltip extends Component {
     iconDescription: 'tooltip',
     triggerText: 'Provide triggerText',
     menuOffset: {},
+    openOnHover: false,
   };
 
   state = {
-    open: this.props.open,
+    open: !this.props.openOnHover && this.props.open,
   };
 
   componentDidMount() {
@@ -45,9 +47,15 @@ export default class Tooltip extends Component {
     }
   };
 
-  handleFocus = direction => {
+  /**
+   * Function to toggle open state, calling getTriggerPosition when opening
+   * @param {boolean} open - what state to toggle to
+   * @memberof Tooltip
+   */
+  toggleOpen = open => {
+    const nextOpenState = typeof open === 'boolean' ? open : !this.state.open;
     /* istanbul ignore next */
-    if (direction === 'focus') {
+    if (nextOpenState) {
       this.getTriggerPosition();
       this.setState({ open: true });
     } else {
@@ -65,6 +73,7 @@ export default class Tooltip extends Component {
       iconName,
       iconDescription,
       menuOffset,
+      openOnHover,
       ...rest
     } = this.props;
 
@@ -73,6 +82,17 @@ export default class Tooltip extends Component {
       { 'bx--tooltip--shown': this.state.open },
       className,
     );
+
+    let triggerProps = {
+      onFocus: () => this.toggleOpen(true),
+      onBlur: () => this.toggleOpen(false),
+    };
+    if (openOnHover) {
+      triggerProps = {
+        onMouseEnter: () => this.toggleOpen(true),
+        onMouseLeave: () => this.toggleOpen(false),
+      };
+    }
 
     return (
       <div>
@@ -83,9 +103,8 @@ export default class Tooltip extends Component {
               ref={node => {
                 this.triggerEl = node;
               }}
-              onFocus={() => this.handleFocus('focus')}
-              onBlur={() => this.handleFocus('blur')}
               className="bx--tooltip__icon-container"
+              {...triggerProps}
             >
               <Icon
                 role="button"
@@ -102,8 +121,7 @@ export default class Tooltip extends Component {
             ref={node => {
               this.triggerEl = node;
             }}
-            onFocus={() => this.handleMouse('over')}
-            onBlur={() => this.handleMouse('out')}
+            {...triggerProps}
           >
             {triggerText}
           </div>


### PR DESCRIPTION
Closes carbon-design-system/carbon-addons-ics#

I like the floating tooltip in that they can 'break out' of their containers (which may have 'overflow hidden' for instance), which was an issue i was running into using the basic TooltipHover components.

This adds a boolean flag that can be used to turn the `Tooltip` component into a floating 'tooltiphover'-esque component

I considered making a higher-order component to track mouse state but it would ultimately need basically everything in this pr as well, so the HOC wasn't saving any code

@j1mie - this pr is against my existing branch because the full functionality depends on that pr. Merging this pr into that one will make these changes show up in that diff (merging that pr first will likely necessitate remaking this pr but I can do that when the time comes)

#### Changelog

**New**

- openOnHover prop for Tooltip component
